### PR TITLE
Use a convention plugin to avoid redundant project configurations

### DIFF
--- a/actorsystem-impl/build.gradle
+++ b/actorsystem-impl/build.gradle
@@ -1,54 +1,10 @@
 plugins {
-    id 'org.jetbrains.kotlin.jvm'
-    id 'org.jlleitschuh.gradle.ktlint'
-    id 'com.adarshr.test-logger'
-    id 'jacoco'
+    id 'actorlang.kotlin-conventions'
 }
 
-group = 'org.actorlang'
-version = '1.1.1-SNAPSHOT'
-archivesBaseName = 'org.actorlang.actorsystem-impl'
-
-repositories {
-    mavenCentral()
-}
-
-jacoco {
-    toolVersion = '0.8.8'
-}
-
-jacocoTestReport {
-    reports {
-        xml.required = false
-        csv.required = false
-        html.outputLocation = file("${buildDir}/reports/jacoco/html")
-    }
-}
+version = parent.version
+archivesBaseName = "${parent.group}.actorsystem-impl"
 
 dependencies {
     implementation project(":actorsystem-servicecontract")
-
-    // Tests
-    testImplementation "org.mockito:mockito-core:3.+"
-    testImplementation 'org.mockito:mockito-inline:3.11.0'
-    testImplementation "org.mockito.kotlin:mockito-kotlin:3.2.0"
-    testImplementation 'org.jetbrains.kotlin:kotlin-test-junit5'
-    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.6.0'
-    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.6.0'
-
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
-    implementation "io.github.microutils:kotlin-logging-jvm:3.0.4"
-    runtimeOnly "org.slf4j:slf4j-simple:2.0.3"
-}
-
-test {
-    useJUnitPlatform()
-}
-
-compileKotlin {
-    kotlinOptions.jvmTarget = '1.8'
-}
-
-compileTestKotlin {
-    kotlinOptions.jvmTarget = '1.8'
 }

--- a/actorsystem-servicecontract/build.gradle
+++ b/actorsystem-servicecontract/build.gradle
@@ -1,50 +1,6 @@
 plugins {
-    id 'org.jetbrains.kotlin.jvm'
-    id 'org.jlleitschuh.gradle.ktlint'
-    id 'com.adarshr.test-logger'
-    id 'jacoco'
+    id 'actorlang.kotlin-conventions'
 }
 
-group = 'org.actorlang'
-version = '1.1.1-SNAPSHOT'
-archivesBaseName = 'org.actorlang.actorsystem-servicecontract'
-
-repositories {
-    mavenCentral()
-}
-
-jacoco {
-    toolVersion = '0.8.8'
-}
-
-jacocoTestReport {
-    reports {
-        xml.required = false
-        csv.required = false
-        html.outputLocation = file("${buildDir}/reports/jacoco/html")
-    }
-}
-
-dependencies {
-    // Tests
-    testImplementation "org.mockito:mockito-core:3.+"
-    testImplementation 'org.mockito:mockito-inline:3.11.0'
-    testImplementation "org.mockito.kotlin:mockito-kotlin:3.2.0"
-    testImplementation 'org.jetbrains.kotlin:kotlin-test-junit5'
-    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.6.0'
-    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.6.0'
-
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
-}
-
-test {
-    useJUnitPlatform()
-}
-
-compileKotlin {
-    kotlinOptions.jvmTarget = '1.8'
-}
-
-compileTestKotlin {
-    kotlinOptions.jvmTarget = '1.8'
-}
+version = parent.version
+archivesBaseName = "${parent.group}.actorsystem-servicecontract"

--- a/build.gradle
+++ b/build.gradle
@@ -1,64 +1,20 @@
 plugins {
-    id 'org.jetbrains.kotlin.jvm' version '1.7.20'
     id 'application'
-    id 'org.jlleitschuh.gradle.ktlint' version '10.0.0'
-    id 'com.adarshr.test-logger' version '3.0.0'
-    id 'jacoco'
+    id 'actorlang.kotlin-conventions'
 }
 
 group = 'org.actorlang'
 version = '1.1.1-SNAPSHOT'
-archivesBaseName = 'org.actorlang.cli'
-
-repositories {
-    mavenCentral()
-}
+archivesBaseName = "${group}.cli"
 
 application {
     mainClass.set('org.actorlang.cli.MainKt')
     applicationName = 'actorlang'
 }
 
-jacoco {
-    toolVersion = '0.8.8'
-}
-
-jacocoTestReport {
-    reports {
-        xml.required = false
-        csv.required = false
-        html.outputLocation = file("${buildDir}/reports/jacoco/html")
-    }
-}
-
 dependencies {
+    implementation project(":actorsystem-servicecontract")
+    implementation project(":actorsystem-impl")
     implementation project(":parser")
     implementation project(":interpreter")
-    implementation project(":actorsystem-impl")
-    implementation project(":actorsystem-servicecontract")
-
-    // Tests
-    testImplementation "org.mockito:mockito-core:3.+"
-    testImplementation 'org.mockito:mockito-inline:3.11.0'
-    testImplementation "org.mockito.kotlin:mockito-kotlin:3.2.0"
-    testImplementation 'org.jetbrains.kotlin:kotlin-test-junit5'
-    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.6.0'
-    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.6.0'
-
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
-
-    implementation "io.github.microutils:kotlin-logging-jvm:3.0.4"
-    runtimeOnly "org.slf4j:slf4j-simple:2.0.3"
-}
-
-test {
-    useJUnitPlatform()
-}
-
-compileKotlin {
-    kotlinOptions.jvmTarget = '1.8'
-}
-
-compileTestKotlin {
-    kotlinOptions.jvmTarget = '1.8'
 }

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -1,0 +1,13 @@
+plugins {
+    id 'groovy-gradle-plugin'
+}
+
+repositories {
+    gradlePluginPortal()
+}
+
+dependencies {
+    implementation 'org.jetbrains.kotlin.jvm:org.jetbrains.kotlin.jvm.gradle.plugin:1.7.20'
+    implementation 'org.jlleitschuh.gradle.ktlint:org.jlleitschuh.gradle.ktlint.gradle.plugin:10.0.0'
+    implementation 'com.adarshr.test-logger:com.adarshr.test-logger.gradle.plugin:3.0.0'
+}

--- a/buildSrc/src/main/groovy/actorlang.kotlin-conventions.gradle
+++ b/buildSrc/src/main/groovy/actorlang.kotlin-conventions.gradle
@@ -1,0 +1,41 @@
+// https://discuss.gradle.org/t/applying-a-plugin-version-inside-a-convention-plugin/42160/2
+plugins {
+    id 'org.jetbrains.kotlin.jvm'
+    id 'org.jlleitschuh.gradle.ktlint'
+    id 'com.adarshr.test-logger'
+    id 'jacoco'
+}
+
+repositories {
+    mavenCentral()
+}
+
+jacoco {
+    toolVersion = '0.8.8'
+}
+
+dependencies {
+    testImplementation "org.mockito:mockito-core:3.+"
+    testImplementation 'org.mockito:mockito-inline:3.11.0'
+    testImplementation "org.mockito.kotlin:mockito-kotlin:3.2.0"
+    testImplementation 'org.jetbrains.kotlin:kotlin-test-junit5'
+    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.6.0'
+    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.6.0'
+
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
+
+    implementation "io.github.microutils:kotlin-logging-jvm:3.0.4"
+    runtimeOnly "org.slf4j:slf4j-simple:2.0.3"
+}
+
+tasks.named('test', Test) {
+    useJUnitPlatform()
+}
+
+tasks.named('compileKotlin') {
+    kotlinOptions.jvmTarget = '1.8'
+}
+
+tasks.named('compileTestKotlin') {
+    kotlinOptions.jvmTarget = '1.8'
+}

--- a/code-coverage-report/build.gradle
+++ b/code-coverage-report/build.gradle
@@ -8,9 +8,6 @@ repositories {
 }
 
 dependencies {
-    jacocoAggregation project(':parser')
-    jacocoAggregation project(':actorsystem-servicecontract')
-    jacocoAggregation project(':actorsystem-impl')
     jacocoAggregation project(':interpreter')
 }
 
@@ -23,14 +20,14 @@ reporting {
 }
 
 tasks.named('check') {
-    dependsOn tasks.named('testCodeCoverageReport', JacocoReport)
+    finalizedBy tasks.named('testCodeCoverageReport')
 }
 
 testCodeCoverageReport {
     afterEvaluate {
         classDirectories.setFrom(files(classDirectories.files.collect {
             fileTree(dir: it, exclude: [
-                // We exclude the parser Java generated sources
+                // We exclude the parser generated sources
                 "org/actorlang/antlr/gen/*"
             ])
         }))

--- a/interpreter/build.gradle
+++ b/interpreter/build.gradle
@@ -1,55 +1,12 @@
 plugins {
-    id 'org.jetbrains.kotlin.jvm'
-    id 'org.jlleitschuh.gradle.ktlint'
-    id 'com.adarshr.test-logger'
-    id 'jacoco'
+    id 'actorlang.kotlin-conventions'
 }
 
-group = 'org.actorlang'
-version = '1.1.1-SNAPSHOT'
-archivesBaseName = 'org.actorlang.interpreter'
-
-repositories {
-    mavenCentral()
-}
-
-jacoco {
-    toolVersion = '0.8.8'
-}
-
-jacocoTestReport {
-    reports {
-        xml.required = false
-        csv.required = false
-        html.outputLocation = file("${buildDir}/reports/jacoco/html")
-    }
-}
+version = parent.version
+archivesBaseName = "${parent.group}.interpreter"
 
 dependencies {
     implementation project(":actorsystem-servicecontract")
     implementation project(":actorsystem-impl")
     implementation project(":parser")
-
-    // Tests
-    testImplementation "org.mockito:mockito-core:3.+"
-    testImplementation 'org.mockito:mockito-inline:3.11.0'
-    testImplementation "org.mockito.kotlin:mockito-kotlin:3.2.0"
-    testImplementation 'org.jetbrains.kotlin:kotlin-test-junit5'
-    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.6.0'
-    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.6.0'
-
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
-    implementation "io.github.microutils:kotlin-logging-jvm:3.0.4"
-    runtimeOnly "org.slf4j:slf4j-simple:2.0.3"
-}
-
-test {
-    useJUnitPlatform()
-}
-compileKotlin {
-    kotlinOptions.jvmTarget = '1.8'
-}
-
-compileTestKotlin {
-    kotlinOptions.jvmTarget = '1.8'
 }

--- a/parser/build.gradle
+++ b/parser/build.gradle
@@ -1,62 +1,32 @@
 plugins {
-    id 'org.jetbrains.kotlin.jvm'
     id 'antlr'
-    id 'org.jlleitschuh.gradle.ktlint'
-    id 'com.adarshr.test-logger'
-    id 'jacoco'
+    id 'actorlang.kotlin-conventions'
 }
 
-group = 'org.actorlang'
-version = '1.1.1-SNAPSHOT'
-archivesBaseName = 'org.actorlang.parser'
+version = parent.version
+archivesBaseName = "${parent.group}.parser"
 
-repositories {
-    mavenCentral()
+dependencies {
+    antlr 'org.antlr:antlr4:4.9'
 }
 
-jacoco {
-    toolVersion = '0.8.8'
-}
-
-generateGrammarSource {
+tasks.named('generateGrammarSource', AntlrTask) {
     arguments += ["-visitor", "-long-messages"]
     outputDirectory = file("src/main/java/")
 }
 
-jacocoTestReport {
-    reports {
-        xml.required = false
-        csv.required = false
-        html.outputLocation = file("${buildDir}/reports/jacoco/html")
-    }
+tasks.named('compileKotlin') {
+    dependsOn tasks.named('generateGrammarSource')
 }
 
-dependencies {
-    antlr 'org.antlr:antlr4:4.9'
-
-    // Tests
-    testImplementation "org.mockito:mockito-core:3.+"
-    testImplementation 'org.mockito:mockito-inline:3.11.0'
-    testImplementation "org.mockito.kotlin:mockito-kotlin:3.2.0"
-    testImplementation 'org.jetbrains.kotlin:kotlin-test-junit5'
-    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.6.0'
-    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.6.0'
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
+tasks.named('compileTestKotlin') {
+    dependsOn tasks.named('generateTestGrammarSource')
 }
 
-test {
-    useJUnitPlatform()
+tasks.named('runKtlintCheckOverMainSourceSet') {
+    dependsOn tasks.named('generateGrammarSource')
 }
 
-compileKotlin {
-    kotlinOptions.jvmTarget = '1.8'
-    dependsOn generateGrammarSource
-}
-
-compileTestKotlin {
-    kotlinOptions.jvmTarget = '1.8'
-}
-
-runKtlintCheckOverMainSourceSet {
-    dependsOn generateGrammarSource
+tasks.named('runKtlintCheckOverTestSourceSet') {
+    dependsOn tasks.named('generateTestGrammarSource')
 }


### PR DESCRIPTION
Also use Gradle configuration avoidance API to speed up builds.